### PR TITLE
Added selfIntersection check

### DIFF
--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -68,6 +68,10 @@ Draw.Cut = Draw.Poly.extend({
         });
     },
     _finishShape() {
+        // if self intersection is not allowed, do not finish the shape!
+        if (!this.options.allowSelfIntersection && this._doesSelfIntersect) {
+            return;
+        }
         const coords = this._layer.getLatLngs();
         const polygonLayer = L.polygon(coords, this.options.pathOptions);
         this._cut(polygonLayer);


### PR DESCRIPTION
Found a bug, steps to reproduce:
1. Draw a polygon
2. Start drawing a cutting shape in it with allowSelfIntersection = false

![selfintersection-false](https://user-images.githubusercontent.com/28083992/49861372-bbe1cc00-fe0c-11e8-8b87-c0a23ee10d05.png)

3. Click on first vortex (as the cursor snaps to it)
4. Shape is cut

![selfintersection-done](https://user-images.githubusercontent.com/28083992/49861385-c4d29d80-fe0c-11e8-843f-2d210de4edac.png)

